### PR TITLE
Fix 'NETWORK_GET_ENTITY_FROM_NETWORK_ID: no object by ID 0'

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -237,12 +237,6 @@ function ActionCleanup()
         end
     end
 
-    DetachEntity(NetToObj(prop_net), 1, 1)
-    DeleteEntity(NetToObj(prop_net))
-    DetachEntity(NetToObj(propTwo_net), 1, 1)
-    DeleteEntity(NetToObj(propTwo_net))
-    prop_net = nil
-    propTwo_net = nil
     runProgThread = false
 end
 


### PR DESCRIPTION
RSG Core never passed entity ID to the progressbar, thus causing this issue. It's better to remove the troublesome routine for now because entity removal usually (99% of the times) takes place in the csource scripts right after the progress bar ended.